### PR TITLE
Useful additions for testing

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 ## New Features
 
 - A new module `frequenz.client.dispatch.test` has been added, providing a fake Service and Client as well as a `DispatchGenerator` to generate `Dispatch` instances filled with random data.
+- The `DispatchGenerator.generate_dispatch` method now accepts a `microgrid_id` parameter to generate `Dispatch` instances with a specific microgrid ID.
 
 ## Bug Fixes
 

--- a/src/frequenz/client/dispatch/_internal_types.py
+++ b/src/frequenz/client/dispatch/_internal_types.py
@@ -16,7 +16,7 @@ from frequenz.api.dispatch.v1.dispatch_pb2 import (
 # pylint: enable=no-name-in-module
 from google.protobuf.json_format import MessageToDict
 
-from frequenz.client.dispatch.types import (
+from .types import (
     ComponentSelector,
     RecurrenceRule,
     component_selector_from_protobuf,

--- a/src/frequenz/client/dispatch/test/_service.py
+++ b/src/frequenz/client/dispatch/test/_service.py
@@ -123,12 +123,15 @@ class FakeService:
         request: DispatchUpdateRequest,
     ) -> Empty:
         """Update a dispatch."""
-        dispatch = next((d for d in self.dispatches if d.id == request.id), None)
+        index = next(
+            (i for i, d in enumerate(self.dispatches) if d.id == request.id),
+            None,
+        )
 
-        if dispatch is None:
+        if index is None:
             return Empty()
 
-        pb_dispatch = dispatch.to_protobuf()
+        pb_dispatch = self.dispatches[index].to_protobuf()
 
         # Go through the paths in the update mask and update the dispatch
         for path in request.update_mask.paths:
@@ -173,6 +176,8 @@ class FakeService:
 
         dispatch = Dispatch.from_protobuf(pb_dispatch)
         dispatch.update_time = datetime.now(tz=timezone.utc)
+
+        self.dispatches[index] = dispatch
 
         return Empty()
 

--- a/src/frequenz/client/dispatch/test/_service.py
+++ b/src/frequenz/client/dispatch/test/_service.py
@@ -5,7 +5,6 @@
 
 Useful for testing.
 """
-
 import dataclasses
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -29,9 +28,8 @@ from frequenz.api.dispatch.v1.dispatch_pb2 import (
 from frequenz.api.dispatch.v1.dispatch_pb2 import DispatchUpdateRequest
 from google.protobuf.empty_pb2 import Empty
 
-from frequenz.client.base.conversion import to_datetime as _to_dt
-
 # pylint: enable=no-name-in-module
+from frequenz.client.base.conversion import to_datetime as _to_dt
 from frequenz.client.dispatch._internal_types import DispatchCreateRequest
 from frequenz.client.dispatch.types import Dispatch
 

--- a/src/frequenz/client/dispatch/test/_service.py
+++ b/src/frequenz/client/dispatch/test/_service.py
@@ -30,8 +30,9 @@ from google.protobuf.empty_pb2 import Empty
 
 # pylint: enable=no-name-in-module
 from frequenz.client.base.conversion import to_datetime as _to_dt
-from frequenz.client.dispatch._internal_types import DispatchCreateRequest
-from frequenz.client.dispatch.types import Dispatch
+
+from .._internal_types import DispatchCreateRequest
+from ..types import Dispatch
 
 
 @dataclass

--- a/src/frequenz/client/dispatch/test/client.py
+++ b/src/frequenz/client/dispatch/test/client.py
@@ -4,8 +4,7 @@
 """Fake client for testing."""
 
 from typing import Any, cast
-
-import grpc.aio
+from unittest.mock import MagicMock
 
 from frequenz.client.dispatch import Client
 from frequenz.client.dispatch.test._service import FakeService
@@ -20,7 +19,7 @@ class FakeClient(Client):
 
     def __init__(self) -> None:
         """Initialize the mock client."""
-        super().__init__(grpc.aio.insecure_channel("mock"), "mock")
+        super().__init__(MagicMock(), "mock")
         self._stub = FakeService()  # type: ignore
 
     @property

--- a/src/frequenz/client/dispatch/test/client.py
+++ b/src/frequenz/client/dispatch/test/client.py
@@ -6,9 +6,9 @@
 from typing import Any, cast
 from unittest.mock import MagicMock
 
-from frequenz.client.dispatch import Client
-from frequenz.client.dispatch.test._service import FakeService
-from frequenz.client.dispatch.types import Dispatch
+from .. import Client
+from ..types import Dispatch
+from ._service import FakeService
 
 
 class FakeClient(Client):

--- a/src/frequenz/client/dispatch/test/generator.py
+++ b/src/frequenz/client/dispatch/test/generator.py
@@ -69,8 +69,11 @@ class DispatchGenerator:
             ],
         )
 
-    def generate_dispatch(self) -> Dispatch:
+    def generate_dispatch(self, microgrid_id: int | None = None) -> Dispatch:
         """Generate a random dispatch instance.
+
+        Args:
+            microgrid_id: The microgrid_id to set on the dispatch.
 
         Returns:
             a random dispatch instance
@@ -84,7 +87,7 @@ class DispatchGenerator:
             id=self._last_id,
             create_time=create_time,
             update_time=create_time + timedelta(seconds=self._rng.randint(0, 1000000)),
-            microgrid_id=self._rng.randint(0, 100),
+            microgrid_id=microgrid_id or self._rng.randint(0, 100),
             type=str(self._rng.randint(0, 100_000)),
             start_time=datetime.now().astimezone(timezone.utc)
             + timedelta(seconds=self._rng.randint(0, 1000000)),

--- a/src/frequenz/client/dispatch/test/generator.py
+++ b/src/frequenz/client/dispatch/test/generator.py
@@ -7,13 +7,8 @@ import random
 from datetime import datetime, timedelta, timezone
 
 from frequenz.client.common.microgrid.components import ComponentCategory
-from frequenz.client.dispatch.types import (
-    Dispatch,
-    EndCriteria,
-    Frequency,
-    RecurrenceRule,
-    Weekday,
-)
+
+from ..types import Dispatch, EndCriteria, Frequency, RecurrenceRule, Weekday
 
 
 class DispatchGenerator:

--- a/src/frequenz/client/dispatch/types.py
+++ b/src/frequenz/client/dispatch/types.py
@@ -148,7 +148,7 @@ class EndCriteria:
 
 
 # pylint: disable=too-many-instance-attributes
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class RecurrenceRule:
     """Ruleset governing when and how a dispatch should re-occur.
 

--- a/tests/test_dispatch_client.py
+++ b/tests/test_dispatch_client.py
@@ -81,6 +81,7 @@ async def test_update_dispatch() -> None:
     assert dispatch == sample
 
     await client.update(dispatch.id, {"recurrence.interval": 4})
+    assert client.dispatches[0].recurrence.interval == 4
 
 
 async def test_get_dispatch() -> None:


### PR DESCRIPTION
- Add and use `DummyChannel` instead of grpc one
- Generator: Allow specifying a microgrid id
- Move pylint warning switch down
