### PR TITLE
Make `Client.update` require named parameters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 ## Upgrading
 
 - The `Dispatch` class is now a frozen dataclass, meaning that it is immutable. Modifications can still be done using `replace`: `dispatch = replace(dispatch, start_time=new_start_time)`.
+- The `Client.update()` method now requires named parameters.
 
 ## New Features
 

--- a/src/frequenz/client/dispatch/_client.py
+++ b/src/frequenz/client/dispatch/_client.py
@@ -166,6 +166,7 @@ class Client:
 
     async def update(
         self,
+        *,
         dispatch_id: int,
         new_fields: dict[str, Any],
     ) -> None:

--- a/tests/test_dispatch_client.py
+++ b/tests/test_dispatch_client.py
@@ -99,7 +99,7 @@ async def test_update_dispatch() -> None:
     sample = _update(sample, dispatch)
     assert dispatch == sample
 
-    await client.update(dispatch.id, {"recurrence.interval": 4})
+    await client.update(dispatch_id=dispatch.id, new_fields={"recurrence.interval": 4})
     assert client.dispatches[0].recurrence.interval == 4
 
 


### PR DESCRIPTION
I noticed it happened often that I used the microgrid id instead of
the dispatch id to identify the to-be-updated dispatch which of course
is wrong.

This should make it more obvious when using the API what kind of ID should
be passed.

Optimally we have distinct types for Microgrid ID and Dispatch ID though.
