### PR TITLE
Disallow updating `type` and `dry_run`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@
 
 - The `Dispatch` class is now a frozen dataclass, meaning that it is immutable. Modifications can still be done using `replace`: `dispatch = replace(dispatch, start_time=new_start_time)`.
 - The `Client.update()` method now requires named parameters.
+- `Client.update()` no longer accepts changes to the `type` and `dry_run` fields.
 
 ## New Features
 

--- a/src/frequenz/client/dispatch/_client.py
+++ b/src/frequenz/client/dispatch/_client.py
@@ -177,9 +177,14 @@ class Client:
 
         For recurrence fields, the keys are preceeded by "recurrence.".
 
+        Note that updating `type` and `dry_run` is not supported.
+
         Args:
             dispatch_id: The dispatch_id to update.
             new_fields: The fields to update.
+
+        Raises:
+            ValueError: If updating `type` or `dry_run`.
         """
         msg = DispatchUpdateRequest(id=dispatch_id)
 
@@ -188,7 +193,7 @@ class Client:
 
             match path[0]:
                 case "type":
-                    msg.update.type = val
+                    raise ValueError("Updating type is not supported")
                 case "start_time":
                     msg.update.start_time.FromDatetime(val)
                 case "duration":
@@ -200,11 +205,8 @@ class Client:
                 case "active":
                     msg.update.is_active = val
                     key = "is_active"
-                case "is_dry_run":
-                    msg.update.is_dry_run = val
-                case "dry_run":
-                    msg.update.is_dry_run = val
-                    key = "is_dry_run"
+                case "is_dry_run" | "dry_run":
+                    raise ValueError("Updating dry_run is not supported")
                 case "recurrence":
                     match path[1]:
                         case "freq":

--- a/tests/test_dispatch_client.py
+++ b/tests/test_dispatch_client.py
@@ -103,6 +103,29 @@ async def test_update_dispatch() -> None:
     assert client.dispatches[0].recurrence.interval == 4
 
 
+async def test_update_dispatch_fail() -> None:
+    """Test updating the type and dry_run fields of a dispatch."""
+    sampler = DispatchGenerator()
+    client = FakeClient()
+    sample = sampler.generate_dispatch()
+
+    await client.create(**to_create_params(sample))
+    dispatch = client.dispatches[0]
+
+    assert dispatch is not None
+
+    sample = _update(sample, dispatch)
+    assert dispatch == sample
+
+    for field, value in [
+        ("type", "new_type"),
+        ("dry_run", True),
+        ("is_dry_run", True),
+    ]:
+        with raises(ValueError):
+            await client.update(dispatch_id=dispatch.id, new_fields={field: value})
+
+
 async def test_get_dispatch() -> None:
     """Test getting a dispatch."""
     sampler = DispatchGenerator()


### PR DESCRIPTION
Refs https://github.com/frequenz-io/frequenz-service-dispatch/issues/76, https://github.com/frequenz-io/frequenz-service-dispatch/issues/74
