### PR TITLE
Initial work to use base client

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,13 +2,16 @@
 
 ## Summary
 
-This release adds support for pagination in the dispatch list request.
+This release includes a new feature for pagination support in the dispatch list request as well as usage of the base-client for setting up the channel and client configuration.
 
 ## Upgrading
 
 - The `Client.list()` function now yields a `list[Dispatch]` representing one page of dispatches
+- `Client.__init__` no longer accepts a `grpc_channel` argument, instead a `server_url` argument is required.
 
 ## New Features
 
 - Pagination support in the dispatch list request.
-
+- `Client.__init__`:
+ - Has a new parameter `connect` which is a boolean that determines if the client should connect to the server on initialization.
+ - Automatically sets up the channel for encrypted TLS communication.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">= 3.11, < 4"
 dependencies = [
   "typing-extensions >= 4.6.1, < 5",
   "frequenz-api-dispatch >= 0.15.1, < 0.16",
-  "frequenz-client-base >= 0.2.1, < 0.5.0",
+  "frequenz-client-base >= 0.6.0, < 0.7.0",
   "frequenz-client-common >= 0.1.0, < 0.3.0",
   "grpcio >= 1.64.1, < 2",
 ]

--- a/src/frequenz/client/dispatch/test/client.py
+++ b/src/frequenz/client/dispatch/test/client.py
@@ -3,8 +3,7 @@
 
 """Fake client for testing."""
 
-from typing import Any, cast
-from unittest.mock import MagicMock
+from typing import Any
 
 from .. import Client
 from ..types import Dispatch
@@ -23,8 +22,17 @@ class FakeClient(Client):
         self,
     ) -> None:
         """Initialize the mock client."""
-        super().__init__(grpc_channel=MagicMock(), svc_addr="mock", key=ALL_KEY)
-        self._stub = FakeService()  # type: ignore
+        super().__init__(server_url="mock", key=ALL_KEY, connect=False)
+        self._stuba: FakeService = FakeService()
+
+    @property
+    def stub(self) -> FakeService:  # type: ignore
+        """The fake service.
+
+        Returns:
+            FakeService: The fake service.
+        """
+        return self._stuba
 
     def dispatches(self, microgrid_id: int) -> list[Dispatch]:
         """List of dispatches.
@@ -53,7 +61,7 @@ class FakeClient(Client):
         Returns:
             FakeService: The fake service.
         """
-        return cast(FakeService, self._stub)
+        return self._stuba
 
 
 def to_create_params(microgrid_id: int, dispatch: Dispatch) -> dict[str, Any]:


### PR DESCRIPTION
Currently on hold as the base client does not seem to easily support using a
custom root certificate authority.
At this point we still need to use that as we're still waiting on [proper certificates](https://github.com/frequenz-io/infrastructure/issues/73)

So this is blocked by either:
* BaseClient supporting custom root certificates.
* Infra giving us an officially recognized SSL certificate.