### PR TITLE
Configure the new labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -50,6 +50,9 @@ body:
         - Documentation (part:docs)
         - Unit, integration and performance tests (part:tests)
         - Build script, CI, dependencies, etc. (part:tooling)
+        - Client (part:client)
+        - Comnand-line interface (part:cli)
+        - Test utilities (test client, fixtures, etc.) (part:test-utils)
     validations:
       required: true
   - type: textarea

--- a/.github/keylabeler.yml
+++ b/.github/keylabeler.yml
@@ -16,3 +16,6 @@ labelMappings:
   "part:tests": "part:tests"
   "part:tooling": "part:tooling"
   "part:❓": "part:❓"
+  "part:cli": "part:cli"
+  "part:client": "part:client"
+  "part:test-utils": "part:test-utils"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -54,3 +54,24 @@
       - CODEOWNERS
       - MANIFEST.in
       - noxfile.py
+
+"part:cli":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/frequenz/client/dispatch/__main__.py"
+      - "src/frequenz/client/dispatch/_cli_*.py"
+
+"part:dispatcher":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/**/*.py"
+    - all-glob-to-all-file:
+      - "!**/conftest.py"
+      - "!src/frequenz/client/dispatch/__main__.py"
+      - "!src/frequenz/client/dispatch/_cli_*.py"
+      - "!src/frequenz/client/dispatch/test/**/*.py"
+
+"part:test-utils":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "src/frequenz/client/dispatch/test/**/*.py"


### PR DESCRIPTION
Use the new labels `part:cli`, `part:client` and `part:test-utils` in the issue template and the labeler configuration.
