### PR TITLE
Update pylint + isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev-flake8 = [
   "pydoclint == 0.6.0",
   "pydocstyle == 6.3.0",
 ]
-dev-formatting = ["black == 25.1.0", "isort == 6.0.0"]
+dev-formatting = ["black == 25.1.0", "isort == 6.0.1"]
 dev-mkdocs = [
   "black == 25.1.0",
   "Markdown==3.7",

--- a/src/frequenz/client/dispatch/_internal_types.py
+++ b/src/frequenz/client/dispatch/_internal_types.py
@@ -12,7 +12,9 @@ from typing import Any, Literal
 from frequenz.api.dispatch.v1.dispatch_pb2 import (
     CreateMicrogridDispatchRequest as PBDispatchCreateRequest,
 )
-from frequenz.api.dispatch.v1.dispatch_pb2 import DispatchData
+from frequenz.api.dispatch.v1.dispatch_pb2 import (
+    DispatchData,
+)
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.struct_pb2 import Struct
 from google.protobuf.timestamp_pb2 import Timestamp


### PR DESCRIPTION
Pylint only supports isort 6+ starting with version 3.3.4
