### PR TITLE
refactor: Adapt code to v1alpha8 API of frequenz-client-common

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,7 +20,7 @@ This release updates the `frequenz-api-dispatch` dependency to `v1.0.0-rc3` and 
 * Support secrets for signing and verifying messages.
   * Use the new env variable `DISPATCH_API_SIGN_SECRET` to set the secret key.
   * Use the new `sign_secret` parameter in the `DispatchClient` constructor to set the secret key.
-* Added `auth_key` parameter to the `dispatch-cli` and thew env variable `DISPATCH_API_AUTH_KEY` to set the authentication key for the Dispatch API.
+* Added `auth_key` parameter to the `dispatch-cli` and the new variable `DISPATCH_API_AUTH_KEY` to set the authentication key for the Dispatch API.
 
 
 ## Bug Fixes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,14 +2,21 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+This release updates the `frequenz-api-dispatch` dependency to `v1.0.0-rc3` and adapts the client to the latest API changes. It introduces more specific component categories and new event names while maintaining backward compatibility.
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+* `InverterType.SOLAR` is now deprecated in favor of `InverterType.PV`. The old name can still be used but will be removed in a future release.
+* The following dependencies were updated:
+  * `frequenz-api-dispatch` to `v1.0.0-rc3`
+  * `frequenz-client-common` to `v0.3.6`
+  * `grpcio` to `v1.72.1`
 
 ## New Features
 
+* **`ElectricalComponentCategory`**: The client now uses the more specific `frequenz.client.common.microgrid.electrical_components.ElectricalComponentCategory` for targeting components.
+  * The new property `TargetCategory.category2` will return an `ElectricalComponentCategory`.
+  * The existing `TargetCategory.category` property is preserved for backward compatibility and returns the corresponding `ComponentCategory`.
 * Support secrets for signing and verifying messages.
   * Use the new env variable `DISPATCH_API_SIGN_SECRET` to set the secret key.
   * Use the new `sign_secret` parameter in the `DispatchClient` constructor to set the secret key.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,11 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "typing-extensions >= 4.13.0, < 5",
-  "frequenz-api-dispatch == 1.0.0-rc2",
+  "frequenz-api-dispatch >= 1.0.0-rc3, < 2",
   "frequenz-client-base >= 0.11.0, < 0.12.0",
-  "frequenz-client-common >= 0.3.2,  < 0.4.0",
+  "frequenz-client-common >= 0.3.6, < 0.4.0",
   "frequenz-core >= 1.0.2, < 2.0.0",
-  "grpcio >= 1.70.0, < 2",
+  "grpcio >= 1.72.1, < 2",
   "python-dateutil >= 2.8.2, < 3.0",
 ]
 dynamic = ["version"]
@@ -64,7 +64,7 @@ cli = [
 dev-flake8 = [
   "flake8 == 7.3.0",
   "flake8-docstrings == 1.7.0",
-  "flake8-pyproject == 1.2.3", # For reading the flake8 config from pyproject.toml
+  "flake8-pyproject == 1.2.3",  # For reading the flake8 config from pyproject.toml
   "pydoclint == 0.6.6",
   "pydocstyle == 6.3.0",
 ]
@@ -75,7 +75,7 @@ dev-mkdocs = [
   "mike == 2.1.3",
   "mkdocs-gen-files == 0.5.0",
   "mkdocs-literate-nav == 0.6.2",
-  "frequenz-api-dispatch == 1.0.0-rc2",
+  "frequenz-api-dispatch == 1.0.0-rc3",
   "mkdocs-macros-plugin == 1.3.7",
   "mkdocs-material == 9.6.16",
   "mkdocstrings[python] == 0.30.0",
@@ -95,7 +95,7 @@ dev-pylint = [
   "pylint == 3.3.7",
   # For checking the noxfile, docs/ script, and tests
   "frequenz-client-dispatch[cli,dev-mkdocs,dev-noxfile,dev-pytest]",
-  "frequenz-api-dispatch == 1.0.0-rc2",
+  "frequenz-api-dispatch == 1.0.0-rc3",
 ]
 dev-pytest = [
   "pytest == 8.4.1",

--- a/src/frequenz/client/dispatch/_cli_types.py
+++ b/src/frequenz/client/dispatch/_cli_types.py
@@ -13,6 +13,9 @@ import parsedatetime  # type: ignore
 from tzlocal import get_localzone
 
 from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+)
 from frequenz.client.dispatch.types import (
     BatteryType,
     EvChargerType,
@@ -177,9 +180,17 @@ class TargetComponentParamType(click.ParamType):
 
         def enum_from_str(
             name: str,
-        ) -> InverterType | BatteryType | EvChargerType | ComponentCategory:
+        ) -> (
+            InverterType
+            | BatteryType
+            | EvChargerType
+            | ElectricalComponentCategory
+            | ComponentCategory
+        ):
             """Convert a string to an enum member."""
             name = name.strip().upper()
+            if name in ElectricalComponentCategory.__members__:
+                return ElectricalComponentCategory[name]
             if name in ComponentCategory.__members__:
                 return ComponentCategory[name]
             if name in InverterType.__members__:
@@ -208,7 +219,7 @@ class TargetComponentParamType(click.ParamType):
             "- METER,INVERTER # A list of component categories\n"
             "- NA_ION,SOLAR # A list of component category types (category is derived)\n"
             "Valid categories:\n"
-            f"{', '.join([cat.name for cat in ComponentCategory])}\n"
+            f"{', '.join([cat.name for cat in ElectricalComponentCategory])}\n"
             "Valid types:\n"
             f"{types_str}\n",
             param,

--- a/src/frequenz/client/dispatch/_client.py
+++ b/src/frequenz/client/dispatch/_client.py
@@ -4,6 +4,7 @@
 """Dispatch API client for Python."""
 from __future__ import annotations
 
+import warnings
 from datetime import datetime, timedelta
 from typing import Any, AsyncIterator, Awaitable, Iterator, Literal, cast
 
@@ -58,7 +59,8 @@ class DispatchApiClient(BaseApiClient[dispatch_pb2_grpc.MicrogridDispatchService
         self,
         *,
         server_url: str,
-        auth_key: str,
+        auth_key: str | None = None,
+        key: str | None = None,
         sign_secret: str | None = None,
         connect: bool = True,
         call_timeout: timedelta = timedelta(seconds=60),
@@ -69,11 +71,27 @@ class DispatchApiClient(BaseApiClient[dispatch_pb2_grpc.MicrogridDispatchService
         Args:
             server_url: The URL of the server to connect to.
             auth_key: API key to use for authentication.
+            key: Deprecated, use `auth_key` instead.
             sign_secret: Optional secret for signing requests.
             connect: Whether to connect to the service immediately.
             call_timeout: Timeout for gRPC calls, default is 60 seconds.
             stream_timeout: Timeout for gRPC streams, default is 5 minutes.
+
+        Raises:
+            TypeError: If neither `auth_key` nor `key` is provided.
         """
+        if key is not None:
+            warnings.warn(
+                "The `key` parameter is deprecated, use `auth_key` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        auth_key = auth_key or key
+        if auth_key is None:
+            raise TypeError(
+                "__init__() missing 1 required keyword-only argument: 'auth_key'"
+            )
+
         super().__init__(
             server_url,
             dispatch_pb2_grpc.MicrogridDispatchServiceStub,

--- a/src/frequenz/client/dispatch/_client.py
+++ b/src/frequenz/client/dispatch/_client.py
@@ -7,8 +7,11 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any, AsyncIterator, Awaitable, Iterator, Literal, cast
 
-# pylint: disable=no-name-in-module
-from frequenz.api.common.v1.pagination.pagination_params_pb2 import PaginationParams
+# pylint: disable-next=no-name-in-module
+from frequenz.api.common.v1alpha8.pagination.pagination_params_pb2 import (
+    PaginationParams,
+)
+from frequenz.api.common.v1alpha8.types.interval_pb2 import Interval as PBInterval
 from frequenz.api.dispatch.v1 import dispatch_pb2_grpc
 from frequenz.api.dispatch.v1.dispatch_pb2 import (
     CreateMicrogridDispatchResponse,
@@ -20,11 +23,6 @@ from frequenz.api.dispatch.v1.dispatch_pb2 import (
     ListMicrogridDispatchesResponse,
     StreamMicrogridDispatchesRequest,
     StreamMicrogridDispatchesResponse,
-)
-from frequenz.api.dispatch.v1.dispatch_pb2 import (
-    TimeIntervalFilter as PBTimeIntervalFilter,
-)
-from frequenz.api.dispatch.v1.dispatch_pb2 import (
     UpdateMicrogridDispatchRequest,
     UpdateMicrogridDispatchResponse,
 )
@@ -170,11 +168,9 @@ class DispatchApiClient(BaseApiClient[dispatch_pb2_grpc.MicrogridDispatchService
 
         def to_interval(
             from_: datetime | None, to: datetime | None
-        ) -> PBTimeIntervalFilter | None:
+        ) -> PBInterval | None:
             return (
-                PBTimeIntervalFilter(
-                    from_time=to_timestamp(from_), to_time=to_timestamp(to)
-                )
+                PBInterval(start_time=to_timestamp(from_), end_time=to_timestamp(to))
                 if from_ or to
                 else None
             )

--- a/src/frequenz/client/dispatch/test/_service.py
+++ b/src/frequenz/client/dispatch/test/_service.py
@@ -14,7 +14,7 @@ import grpc
 import grpc.aio
 
 # pylint: disable=no-name-in-module
-from frequenz.api.common.v1.pagination.pagination_info_pb2 import PaginationInfo
+from frequenz.api.common.v1alpha8.pagination.pagination_info_pb2 import PaginationInfo
 from frequenz.api.dispatch.v1.dispatch_pb2 import (
     CreateMicrogridDispatchRequest as PBDispatchCreateRequest,
 )
@@ -36,9 +36,10 @@ from google.protobuf.empty_pb2 import Empty
 # pylint: enable=no-name-in-module
 from frequenz.client.base.conversion import to_datetime as _to_dt
 from frequenz.client.common.microgrid import MicrogridId
+from frequenz.client.common.streaming import Event
 
 from .._internal_types import DispatchCreateRequest
-from ..types import Dispatch, DispatchEvent, DispatchId, Event
+from ..types import Dispatch, DispatchEvent, DispatchId
 
 _logger = logging.getLogger(__name__)
 
@@ -148,20 +149,20 @@ class FakeService:
                 if target != dispatch.target:
                     return False
             if _filter.HasField("start_time_interval"):
-                if start_from := _filter.start_time_interval.from_time:
+                if start_from := _filter.start_time_interval.start_time:
                     if dispatch.start_time < _to_dt(start_from):
                         return False
-                if start_to := _filter.start_time_interval.to_time:
+                if start_to := _filter.start_time_interval.end_time:
                     if dispatch.start_time >= _to_dt(start_to):
                         return False
             if _filter.HasField("end_time_interval"):
-                if end_from := _filter.end_time_interval.from_time:
+                if end_from := _filter.end_time_interval.start_time:
                     if (
                         dispatch.duration
                         and dispatch.start_time + dispatch.duration < _to_dt(end_from)
                     ):
                         return False
-                if end_to := _filter.end_time_interval.to_time:
+                if end_to := _filter.end_time_interval.end_time:
                     if (
                         dispatch.duration
                         and dispatch.start_time + dispatch.duration >= _to_dt(end_to)

--- a/src/frequenz/client/dispatch/test/generator.py
+++ b/src/frequenz/client/dispatch/test/generator.py
@@ -6,7 +6,9 @@
 import random
 from datetime import datetime, timedelta, timezone
 
-from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+)
 
 from .._internal_types import rounded_start_time
 from ..recurrence import EndCriteria, Frequency, RecurrenceRule, Weekday
@@ -82,15 +84,15 @@ class DispatchGenerator:
         Returns:
             a random category and type
         """
-        category = self._rng.choice(list(ComponentCategory)[1:])
+        category = self._rng.choice(list(ElectricalComponentCategory)[1:])
         category_type: BatteryType | InverterType | EvChargerType | None = None
 
         match category:
-            case ComponentCategory.BATTERY:
+            case ElectricalComponentCategory.BATTERY:
                 category_type = self._rng.choice(list(BatteryType)[1:])
-            case ComponentCategory.INVERTER:
+            case ElectricalComponentCategory.INVERTER:
                 category_type = self._rng.choice(list(InverterType)[1:])
-            case ComponentCategory.EV_CHARGER:
+            case ElectricalComponentCategory.EV_CHARGER:
                 category_type = self._rng.choice(list(EvChargerType)[1:])
             case _:
                 category_type = None
@@ -116,7 +118,7 @@ class DispatchGenerator:
                 *[
                     # Not yet used
                     # self.generate_target_category_and_type()
-                    self._rng.choice(list(ComponentCategory)[1:])
+                    self._rng.choice(list(ElectricalComponentCategory)[1:])
                     for _ in range(self._rng.randint(1, 10))
                 ]
             ),

--- a/src/frequenz/client/dispatch/types.py
+++ b/src/frequenz/client/dispatch/types.py
@@ -10,13 +10,13 @@ from enum import Enum
 from typing import Any, Self, SupportsInt, TypeAlias, cast, final
 
 # pylint: enable=no-name-in-module
-from frequenz.api.common.v1.microgrid.components.battery_pb2 import (
+from frequenz.api.common.v1alpha8.microgrid.electrical_components.electrical_components_pb2 import (
     BatteryType as PBBatteryType,
 )
-from frequenz.api.common.v1.microgrid.components.ev_charger_pb2 import (
+from frequenz.api.common.v1alpha8.microgrid.electrical_components.electrical_components_pb2 import (
     EvChargerType as PBEvChargerType,
 )
-from frequenz.api.common.v1.microgrid.components.inverter_pb2 import (
+from frequenz.api.common.v1alpha8.microgrid.electrical_components.electrical_components_pb2 import (
     InverterType as PBInverterType,
 )
 
@@ -33,9 +33,31 @@ from google.protobuf.json_format import MessageToDict
 from google.protobuf.struct_pb2 import Struct
 
 from frequenz.client.base.conversion import to_datetime, to_timestamp
-from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.common.microgrid.components import (
+    ComponentCategory,
+)
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+)
+from frequenz.client.common.streaming import Event
 
 from .recurrence import Frequency, RecurrenceRule, Weekday
+
+# Re-export Event for backwards compatibility
+__all__ = [
+    "Event",
+    "Dispatch",
+    "DispatchEvent",
+    "DispatchId",
+    "EvChargerType",
+    "BatteryType",
+    "InverterType",
+    "TargetCategory",
+    "TargetIds",
+    "TargetCategories",
+    "TargetComponents",
+    "TimeIntervalFilter",
+]
 
 
 @final
@@ -81,8 +103,11 @@ class InverterType(Enum):
     BATTERY = PBInverterType.INVERTER_TYPE_BATTERY
     """Battery inverter."""
 
-    SOLAR = PBInverterType.INVERTER_TYPE_SOLAR
+    PV = PBInverterType.INVERTER_TYPE_PV
     """Solar inverter."""
+
+    SOLAR = PBInverterType.INVERTER_TYPE_PV
+    """Deprecated, Solar inverter."""
 
     HYBRID = PBInverterType.INVERTER_TYPE_HYBRID
     """Hybrid inverter."""
@@ -92,11 +117,36 @@ class InverterType(Enum):
 class TargetCategory:
     """Represents a category and optionally a type."""
 
-    target: ComponentCategory | BatteryType | EvChargerType | InverterType
+    target: (
+        ComponentCategory
+        | ElectricalComponentCategory
+        | BatteryType
+        | EvChargerType
+        | InverterType
+    )
     """The target category of the dispatch.
 
     Implicitly derived from the types.
     """
+
+    @property
+    def category2(self) -> ElectricalComponentCategory:
+        """Get the category of the target.
+
+        Returns:
+            The category of the target.
+        """
+        match self.target:
+            case ElectricalComponentCategory():
+                return self.target
+            case ComponentCategory():
+                return ElectricalComponentCategory(self.target.value)
+            case BatteryType():
+                return ElectricalComponentCategory.BATTERY
+            case EvChargerType():
+                return ElectricalComponentCategory.EV_CHARGER
+            case InverterType():
+                return ElectricalComponentCategory.INVERTER
 
     @property
     def category(self) -> ComponentCategory:
@@ -106,6 +156,8 @@ class TargetCategory:
             The category of the target.
         """
         match self.target:
+            case ElectricalComponentCategory():
+                return ComponentCategory(self.target.value)
             case ComponentCategory():
                 return self.target
             case BatteryType():
@@ -151,7 +203,12 @@ class TargetIds(frozenset[int]):
 
 # Define the union of types that can be passed to TargetCategories constructor
 TargetCategoryInputType = (
-    TargetCategory | ComponentCategory | BatteryType | InverterType | EvChargerType
+    TargetCategory
+    | ComponentCategory
+    | ElectricalComponentCategory
+    | BatteryType
+    | InverterType
+    | EvChargerType
 )
 """Type for the input to TargetCategories constructor."""
 
@@ -180,8 +237,18 @@ class TargetCategories(frozenset[TargetCategory]):
         for item in categories_input:
             if isinstance(item, TargetCategory):
                 processed_elements.append(item)
+            elif isinstance(item, ComponentCategory):
+                processed_elements.append(
+                    TargetCategory(target=ElectricalComponentCategory(item.value))
+                )
             elif isinstance(
-                item, (ComponentCategory, BatteryType, InverterType, EvChargerType)
+                item,
+                (
+                    ElectricalComponentCategory,
+                    BatteryType,
+                    InverterType,
+                    EvChargerType,
+                ),
             ):
                 # Wrap raw categories/types into TargetCategory instances
                 processed_elements.append(TargetCategory(target=item))
@@ -236,7 +303,7 @@ def _target_components_from_protobuf(
         case "component_categories":
             return TargetCategories(
                 *map(
-                    ComponentCategory.from_proto,
+                    ElectricalComponentCategory.from_proto,
                     pb_target.component_categories.categories,
                 )
             )
@@ -244,7 +311,7 @@ def _target_components_from_protobuf(
             return TargetCategories(
                 *map(
                     lambda cat_and_type: _extract_category_type(cat_and_type)
-                    or ComponentCategory.from_proto(cat_and_type.category),
+                    or ElectricalComponentCategory.from_proto(cat_and_type.category),
                     pb_target.component_categories_types.categories,
                 )
             )
@@ -274,41 +341,7 @@ def _extract_category_type(
             return None
 
 
-# Old, soon deprecated way to specify categories
 def _target_components_to_protobuf(
-    target: TargetComponents,
-) -> PBTargetComponents:
-    """Convert target components to protobuf.
-
-    Args:
-        target: The target components to convert.
-
-    Raises:
-        ValueError: If the target components are invalid.
-
-    Returns:
-        The converted protobuf target components.
-    """
-    pb_target = PBTargetComponents()
-    match target:
-        case TargetIds(component_ids):
-            pb_target.component_ids.ids.extend(component_ids)
-        case TargetCategories(categories):
-            # Old, soon deprecated way to specify categories
-            pb_target.component_categories.categories.extend(
-                map(
-                    lambda cat: cat.category.to_proto(),
-                    categories,
-                )
-            )
-
-        case _:
-            raise ValueError(f"Invalid target components: {target}")
-    return pb_target
-
-
-# New, not yet supported way to specify categories and types
-def _target_components_to_protobuf_new(
     target: TargetComponents,
 ) -> PBTargetComponents:
     """Convert target components to protobuf.
@@ -329,7 +362,7 @@ def _target_components_to_protobuf_new(
         case TargetCategories(categories):
             for category in categories:
                 pb_category = pb_target.component_categories_types.categories.add()
-                pb_category.category = category.category.to_proto()
+                pb_category.category = category.category2.to_proto()
 
                 match category.type:
                     case BatteryType():
@@ -615,15 +648,6 @@ class Dispatch:  # pylint: disable=too-many-instance-attributes
                 recurrence=self.recurrence.to_protobuf() if self.recurrence else None,
             ),
         )
-
-
-class Event(Enum):
-    """Enum representing the type of event that occurred during a dispatch operation."""
-
-    UNSPECIFIED = StreamMicrogridDispatchesResponse.Event.EVENT_UNSPECIFIED
-    CREATED = StreamMicrogridDispatchesResponse.Event.EVENT_CREATED
-    UPDATED = StreamMicrogridDispatchesResponse.Event.EVENT_UPDATED
-    DELETED = StreamMicrogridDispatchesResponse.Event.EVENT_DELETED
 
 
 @dataclass(kw_only=True, frozen=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,9 @@ from asyncclick.testing import CliRunner
 from tzlocal import get_localzone
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+)
 from frequenz.client.dispatch.__main__ import cli
 from frequenz.client.dispatch.recurrence import (
     EndCriteria,
@@ -238,7 +240,7 @@ async def test_list_command(
             "test",
             timedelta(hours=1),
             timedelta(seconds=3600),
-            TargetCategories(ComponentCategory.BATTERY),
+            TargetCategories(ElectricalComponentCategory.BATTERY),
             {"active": False},
             RecurrenceRule(),
             0,
@@ -309,7 +311,7 @@ async def test_list_command(
             "test",
             timedelta(hours=1),
             timedelta(seconds=3600),
-            TargetCategories(ComponentCategory.CHP),
+            TargetCategories(ElectricalComponentCategory.CHP),
             {},
             RecurrenceRule(
                 frequency=Frequency.HOURLY,
@@ -344,7 +346,7 @@ async def test_list_command(
             "test50",
             timedelta(hours=5),
             timedelta(seconds=3600),
-            TargetCategories(ComponentCategory.EV_CHARGER),
+            TargetCategories(ElectricalComponentCategory.EV_CHARGER),
             {},
             RecurrenceRule(
                 frequency=Frequency.DAILY,
@@ -372,7 +374,7 @@ async def test_list_command(
             "test_start_immediately",
             "NOW",
             timedelta(seconds=3600),
-            TargetCategories(ComponentCategory.BATTERY),
+            TargetCategories(ElectricalComponentCategory.BATTERY),
             {},
             RecurrenceRule(),
             0,
@@ -457,7 +459,7 @@ async def test_create_command(
                     type="test",
                     start_time=datetime(2023, 1, 1, 0, 0, 0),
                     duration=timedelta(seconds=3600),
-                    target=TargetCategories(ComponentCategory.BATTERY),
+                    target=TargetCategories(ElectricalComponentCategory.BATTERY),
                     active=True,
                     dry_run=False,
                     payload={},
@@ -481,7 +483,7 @@ async def test_create_command(
                     type="test",
                     start_time=datetime(2023, 1, 1, 0, 0, 0),
                     duration=timedelta(seconds=3600),
-                    target=TargetCategories(ComponentCategory.BATTERY),
+                    target=TargetCategories(ElectricalComponentCategory.BATTERY),
                     active=True,
                     dry_run=False,
                     payload={},
@@ -508,7 +510,8 @@ async def test_create_command(
                     start_time=datetime(2023, 1, 1, 0, 0, 0),
                     duration=timedelta(seconds=3600),
                     target=TargetCategories(
-                        ComponentCategory.BATTERY, ComponentCategory.EV_CHARGER
+                        ElectricalComponentCategory.BATTERY,
+                        ElectricalComponentCategory.EV_CHARGER,
                     ),
                     active=True,
                     dry_run=False,
@@ -524,9 +527,9 @@ async def test_create_command(
             ],
             {
                 "target": TargetCategories(
-                    ComponentCategory.BATTERY,
-                    ComponentCategory.EV_CHARGER,
-                    ComponentCategory.CHP,
+                    ElectricalComponentCategory.BATTERY,
+                    ElectricalComponentCategory.EV_CHARGER,
+                    ElectricalComponentCategory.CHP,
                 ),
             },
             0,

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -9,7 +9,9 @@ from datetime import datetime, timedelta, timezone
 import pytest
 import time_machine
 
-from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+)
 from frequenz.client.dispatch.recurrence import Frequency, RecurrenceRule, Weekday
 from frequenz.client.dispatch.types import (
     Dispatch,
@@ -30,7 +32,7 @@ def dispatch_base() -> Dispatch:
         type="TypeA",
         start_time=CURRENT_TIME,
         duration=timedelta(minutes=20),
-        target=TargetCategories(ComponentCategory.BATTERY),
+        target=TargetCategories(ElectricalComponentCategory.BATTERY),
         active=True,
         dry_run=False,
         payload={},

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -6,7 +6,9 @@
 from datetime import datetime, timedelta, timezone
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.common.microgrid.electrical_components import (
+    ElectricalComponentCategory,
+)
 from frequenz.client.dispatch._internal_types import DispatchCreateRequest
 from frequenz.client.dispatch.recurrence import (
     EndCriteria,
@@ -24,31 +26,33 @@ from frequenz.client.dispatch.types import (
     TargetCategory,
     TargetIds,
     _target_components_from_protobuf,
-    _target_components_to_protobuf_new,
+    _target_components_to_protobuf,
 )
 
 CaT = TargetCategory
 """Shortcut for the lazy."""
 
 
-def test_target_components_new() -> None:
+def test_target_components() -> None:
     """Test the target components."""
     for components in (
         TargetIds(1, 2, 3),
         TargetIds(10, 20, 30),
-        TargetCategories(ComponentCategory.BATTERY),
-        TargetCategories(ComponentCategory.GRID),
-        TargetCategories(ComponentCategory.METER),
-        TargetCategories(ComponentCategory.EV_CHARGER, ComponentCategory.BATTERY),
+        TargetCategories(ElectricalComponentCategory.BATTERY),
+        TargetCategories(ElectricalComponentCategory.GRID_CONNECTION_POINT),
+        TargetCategories(ElectricalComponentCategory.METER),
+        TargetCategories(
+            ElectricalComponentCategory.EV_CHARGER, ElectricalComponentCategory.BATTERY
+        ),
         TargetCategories(TargetCategory(BatteryType.LI_ION)),
         TargetCategories(
             TargetCategory(BatteryType.NA_ION),
-            TargetCategory(InverterType.SOLAR),
+            TargetCategory(InverterType.PV),
             TargetCategory(EvChargerType.AC),
-            TargetCategory(ComponentCategory.METER),
+            TargetCategory(ElectricalComponentCategory.METER),
         ),
     ):
-        protobuf = _target_components_to_protobuf_new(components)
+        protobuf = _target_components_to_protobuf(components)
         assert _target_components_from_protobuf(protobuf) == components
 
 
@@ -138,7 +142,7 @@ def test_dispatch() -> None:
             start_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             end_time=datetime(2024, 11, 20, tzinfo=timezone.utc),
             duration=timedelta(seconds=20),
-            target=TargetCategories(ComponentCategory.BATTERY),
+            target=TargetCategories(ElectricalComponentCategory.BATTERY),
             active=False,
             dry_run=True,
             payload={"key": "value1"},
@@ -158,7 +162,7 @@ def test_dispatch() -> None:
             start_time=datetime(2024, 11, 10, tzinfo=timezone.utc),
             end_time=None,
             duration=timedelta(seconds=20),
-            target=TargetCategories(ComponentCategory.BATTERY),
+            target=TargetCategories(ElectricalComponentCategory.BATTERY),
             active=False,
             dry_run=True,
             payload={"key": "value1"},


### PR DESCRIPTION
The `frequenz-client-common` dependency has been updated, which introduced breaking changes from the new `v1alpha8` API. This commit adapts the codebase to these changes, resolving the resulting `nox` failures across `mypy`, `pytest`, and formatters.

Key changes include:
- Replacing the deprecated `ComponentCategory` with `v1alpha8`'s `ElectricalComponentCategory`.
- Updating enum members to match the new API, such as `ElectricalComponentCategory.GRID` to `GRID_CONNECTION_POINT` and `InverterType.PV` to `InverterType.SOLAR`.
