### PR TITLE
Prepare for v1.0.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,12 +10,8 @@
 
 ## New Features
 
-* Changed `target_components`, `dispatch_ids`, and `filter_queries` parameters from `Iterator` to `Iterable` in `list` method for better API usability
-* Added support for `dispatch_ids` and `queries` filters in the `list` method
-  - `dispatch_ids` parameter allows filtering by specific dispatch IDs
-  - `filter_queries` parameter supports text-based filtering on dispatch `id` and `type` fields
-      - Query format: IDs are prefixed with `#` (e.g., `#4`), types are matched as substrings (e.g., `bar` matches `foobar`)
-      - Multiple queries are combined with logical OR
-* Date-only inputs in CLI timestamps now default to midnight UTC instead of using the current time.
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes
+
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "typing-extensions >= 4.13.0, < 5",
-  "frequenz-api-dispatch >= 1.0.0-rc3, < 2",
+  "frequenz-api-dispatch >= 1.0.0, < 2",
   "frequenz-client-base >= 0.11.0, < 0.12.0",
   "frequenz-client-common >= 0.3.6, < 0.4.0",
   "frequenz-core >= 1.0.2, < 2.0.0",
@@ -75,7 +75,7 @@ dev-mkdocs = [
   "mike == 2.1.3",
   "mkdocs-gen-files == 0.5.0",
   "mkdocs-literate-nav == 0.6.2",
-  "frequenz-api-dispatch == 1.0.0-rc3",
+  "frequenz-api-dispatch == 1.0.0",
   "mkdocs-macros-plugin == 1.4.0",
   "mkdocs-material == 9.6.21",
   "mkdocstrings[python] == 0.30.1",
@@ -95,7 +95,7 @@ dev-pylint = [
   "pylint == 3.3.9",
   # For checking the noxfile, docs/ script, and tests
   "frequenz-client-dispatch[cli,dev-mkdocs,dev-noxfile,dev-pytest]",
-  "frequenz-api-dispatch == 1.0.0-rc3",
+  "frequenz-api-dispatch == 1.0.0",
 ]
 dev-pytest = [
   "pytest == 8.4.2",


### PR DESCRIPTION
- **Reset release notes for next release**
- **Update freunz-api-dispatch dependency to 1.0.0**
