### PR TITLE
Fix: Change list method parameters from Iterator to Iterable for better API usability

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@
 
 ## New Features
 
+* Changed `target_components`, `dispatch_ids`, and `filter_queries` parameters from `Iterator` to `Iterable` in `list` method for better API usability
 * Added support for `dispatch_ids` and `queries` filters in the `list` method
   - `dispatch_ids` parameter allows filtering by specific dispatch IDs
   - `filter_queries` parameter supports text-based filtering on dispatch `id` and `type` fields
@@ -18,4 +19,3 @@
 * Date-only inputs in CLI timestamps now default to midnight UTC instead of using the current time.
 
 ## Bug Fixes
-

--- a/src/frequenz/client/dispatch/_client.py
+++ b/src/frequenz/client/dispatch/_client.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import warnings
 from datetime import datetime, timedelta
-from typing import Any, AsyncIterator, Awaitable, Iterator, Literal, cast
+from typing import Any, AsyncIterator, Awaitable, Iterable, Iterator, Literal, cast
 
 # pylint: disable-next=no-name-in-module
 from frequenz.api.common.v1alpha8.pagination.pagination_params_pb2 import (
@@ -138,15 +138,15 @@ class DispatchApiClient(BaseApiClient[dispatch_pb2_grpc.MicrogridDispatchService
         self,
         microgrid_id: MicrogridId,
         *,
-        target_components: Iterator[TargetComponents] = iter(()),
+        target_components: Iterable[TargetComponents] = (),
         start_from: datetime | None = None,
         start_to: datetime | None = None,
         end_from: datetime | None = None,
         end_to: datetime | None = None,
         active: bool | None = None,
         dry_run: bool | None = None,
-        dispatch_ids: Iterator[DispatchId] = iter(()),
-        filter_queries: Iterator[str] = iter(()),
+        dispatch_ids: Iterable[DispatchId] = (),
+        filter_queries: Iterable[str] = (),
         page_size: int | None = None,
     ) -> AsyncIterator[Iterator[Dispatch]]:
         """List dispatches.


### PR DESCRIPTION
- Changed target_components, dispatch_ids, and filter_queries parameters
  from Iterator to Iterable in the list method
- This allows users to pass any iterable (list, tuple, generator, etc.)
  instead of requiring specific iterator types
- Improves API flexibility and usability
