### PR TITLE
Make CODEOWNERS more specific

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # Fallback owner.
 # These are the default owners for everything in the repo, unless a later match
 # takes precedence.
-* @frequenz-floss/api-dispatch-team @frequenz-floss/python-sdk-team
+/{src,tests,docs,dist}/ @frequenz-floss/api-dispatch-team @frequenz-floss/python-sdk-team


### PR DESCRIPTION
That way dependabot PRs will be auto-merged as no owners are required for the pyproject.toml file.
