### PR TITLE
Revert "Make CODEOWNERS more specific"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # Fallback owner.
 # These are the default owners for everything in the repo, unless a later match
 # takes precedence.
-/{src,tests,docs,dist}/ @frequenz-floss/api-dispatch-team @frequenz-floss/python-sdk-team
+* @frequenz-floss/api-dispatch-team @frequenz-floss/python-sdk-team


### PR DESCRIPTION
This reverts commit 95082b6731212c734bf2fe926379517da0f06ccb.
We decided to instead make the CODEOWNERS not required for approval